### PR TITLE
Fixed stored @State properties on App

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -4,3 +4,4 @@
 - [Greg Cotten](https://github.com/gregcotten)
 - [Zev Eisenberg](https://github.com/ZevEisenberg)
 - [Jay Wren](https://github.com/jrwren)
+- [Amzd](https://github.com/amzd)

--- a/Sources/Adwaita/Model/User Interface/App/App.swift
+++ b/Sources/Adwaita/Model/User Interface/App/App.swift
@@ -24,7 +24,7 @@
 public protocol App {
 
     /// The app's application ID.
-    static var id: String { get }
+    var id: String { get }
 
     /// The app's windows.
     @SceneBuilder var scene: Scene { get }
@@ -40,12 +40,8 @@ public protocol App {
 
 extension App {
 
-    @available(*, deprecated, message: "The 'id' property is removed. Please use the new static id instead.")
-    var id: String { Self.id }
-
     /// The application's entry point.
     public static func main() {
-        GTUIApp.appID = Self.id
         let app = setupApp()
         app.run()
     }
@@ -55,7 +51,7 @@ extension App {
     /// To run the app, call the ``GTUIApp/run(automaticSetup:manualSetup:)`` function.
     public static func setupApp() -> GTUIApp {
         var appInstance = self.init()
-        appInstance.app = GTUIApp(Self.id) { appInstance }
+        appInstance.app = GTUIApp(appInstance.id) { appInstance }
         GTUIApp.updateHandlers.append { force in
             var removeIndices: [Int] = []
             for (index, window) in appInstance.app.sceneStorage.enumerated() {
@@ -69,6 +65,7 @@ extension App {
                 appInstance.app.sceneStorage.remove(at: index)
             }
         }
+        GTUIApp.appID = appInstance.id
         return appInstance.app
     }
 

--- a/Sources/Adwaita/Model/User Interface/App/App.swift
+++ b/Sources/Adwaita/Model/User Interface/App/App.swift
@@ -24,7 +24,8 @@
 public protocol App {
 
     /// The app's application ID.
-    var id: String { get }
+    static var id: String { get }
+
     /// The app's windows.
     @SceneBuilder var scene: Scene { get }
     // swiftlint:disable implicitly_unwrapped_optional
@@ -39,8 +40,12 @@ public protocol App {
 
 extension App {
 
+    @available(*, deprecated, message: "The 'id' property is removed. Please use the new static id instead.")
+    var id: String { Self.id }
+
     /// The application's entry point.
     public static func main() {
+        GTUIApp.appID = Self.id
         let app = setupApp()
         app.run()
     }
@@ -50,7 +55,7 @@ extension App {
     /// To run the app, call the ``GTUIApp/run(automaticSetup:manualSetup:)`` function.
     public static func setupApp() -> GTUIApp {
         var appInstance = self.init()
-        appInstance.app = GTUIApp(appInstance.id) { appInstance }
+        appInstance.app = GTUIApp(Self.id) { appInstance }
         GTUIApp.updateHandlers.append { force in
             var removeIndices: [Int] = []
             for (index, window) in appInstance.app.sceneStorage.enumerated() {
@@ -64,7 +69,6 @@ extension App {
                 appInstance.app.sceneStorage.remove(at: index)
             }
         }
-        GTUIApp.appID = appInstance.id
         return appInstance.app
     }
 

--- a/Sources/Adwaita/Model/User Interface/App/GTUIApp.swift
+++ b/Sources/Adwaita/Model/User Interface/App/GTUIApp.swift
@@ -13,8 +13,7 @@ public class GTUIApp {
     /// The handlers which are called when a state changes.
     static var updateHandlers: [(Bool) -> Void] = []
     /// The app's id for the file name for storing the data.
-    static var appID = "temporary"
-
+    static var appID: String!
     /// The pointer to the application.
     public var pointer: UnsafeMutablePointer<GtkApplication>?
     /// Fields for additional information.

--- a/Sources/Adwaita/Model/User Interface/App/GTUIApp.swift
+++ b/Sources/Adwaita/Model/User Interface/App/GTUIApp.swift
@@ -13,7 +13,7 @@ public class GTUIApp {
     /// The handlers which are called when a state changes.
     static var updateHandlers: [(Bool) -> Void] = []
     /// The app's id for the file name for storing the data.
-    static var appID: String!
+    static var appID: String?
     /// The pointer to the application.
     public var pointer: UnsafeMutablePointer<GtkApplication>?
     /// Fields for additional information.


### PR DESCRIPTION
## Steps
- [x] Add your name or username and a link to your GitHub profile into the [Contributors.md][1] file.
- [x] Build the project on your machine. If it does not compile, fix the errors.
- [x] Describe the purpose and approach of your pull request below.
- [x] Submit the pull request. Thank you very much for your contribution!

## Purpose
Currently when using a `State` property with storage on `App` instead of on a `View`, the app ID was accessed before it was set, causing the `State` internals to look for the data in the folder `temporary/` which usually doesn't exist because at the time you will be writing into the `State` the app ID will be set and it writes the value into `app.id/` folder.

This happened because when the `State` property is on `App` it is initialized before `GTUIApp.appID` is set.

```swift
struct ExampleApp: App {
    let id = "me.amzd.Example"
    var app: GTUIApp!

    /// This State will try to read its value for the key example from disk before we can access `id`
    /// (because we need to initialize ExampleApp to access the id property)
    @State("example") var example: String?
    
    // ...
}
```
## Approach
I fixed this by making the `App.id` property static and forwarding it to `GTUIApp.appID` first thing the program does. I have also made the `GTUIApp.appID` force unwrapped optional so regression of this issue is not possible.

I am open to suggestions of how to fix this differently. You can also fix this yourself in a different way without crediting, it is not that complicated.

Since it is a breaking change I still need to update the examples

[1]:	/Contributors.md
